### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,7 @@ email=tirithen@gmail.com
 maintainer=Fredrik Söderström <tirithen@gmail.com>
 sentence=Simplifies controlling Proove power outlets with Arduino.
 paragraph=An Arduino library that is used for sending radio signals with an 433Mhz transmitter to Proove (http://proovesmart.com/default/products) power outlets.
+category=Device Control
 url=https://github.com/tirithen/Arduino-ProoveSignal
 architectures=*
 dependencies=


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library ProoveSignal is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
