### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,19 +5,19 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-ProoveSignal KEYWORD1
+ProoveSignal	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-prooveSignalSend    KEYWORD2
-unit                KEYWORD2
-channel             KEYWORD2
-status              KEYWORD2
-group               KEYWORD2
-remote              KEYWORD2
-parts               KEYWORD2
-data                KEYWORD2
+prooveSignalSend	KEYWORD2
+unit	KEYWORD2
+channel	KEYWORD2
+status	KEYWORD2
+group	KEYWORD2
+remote	KEYWORD2
+parts	KEYWORD2
+data	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords